### PR TITLE
[feat]: Cookie Based Presentation Favoriting

### DIFF
--- a/cypress/e2e/presentations.cy.js
+++ b/cypress/e2e/presentations.cy.js
@@ -1,4 +1,7 @@
 describe("Presentations Page", () => {
+  const presentationId = "7415a027-865c-4112-aff4-f617cc3093d2";
+  const presentationDetailUrl = `presentations/${presentationId}`;
+  const presentationFavoriteToggle = `favorite-${presentationId}`;
   it("should load presentations and allow for search", () => {
     cy.visit("/presentations");
 
@@ -21,10 +24,7 @@ describe("Presentations Page", () => {
     cy.getByTestId("presentation-search").type("transform customized");
     cy.getByTestId("presentation-row").should("have.length", 1);
     cy.get("a").click();
-    cy.url().should(
-      "include",
-      "/presentations/7415a027-865c-4112-aff4-f617cc3093d2",
-    );
+    cy.url().should("include", presentationDetailUrl);
     cy.contains("transform customized e-markets");
   });
 
@@ -36,55 +36,39 @@ describe("Presentations Page", () => {
   it("should allow for favoriting/unfavoriting", () => {
     cy.visit("/presentations");
     // initial state is unfavorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♡",
-    );
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
     // toggle to be favorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
 
     // toggle off
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♡",
-    );
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
   });
 
   it("should allow for favoriting on list page, favorite persists on detail page", () => {
     cy.visit("/presentations");
     // initial state is unfavorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♡",
-    );
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
     // toggle to be favorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
 
     // toggle off
-    cy.visit("/presentations/7415a027-865c-4112-aff4-f617cc3093d2");
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
+    cy.visit(presentationDetailUrl);
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
   });
 
   it("should allow for favoriting on detail page, favorite persists on list page", () => {
-    cy.visit("/presentations/7415a027-865c-4112-aff4-f617cc3093d2");
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♡",
-    );
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
+    cy.visit(presentationDetailUrl);
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
 
     // toggle off
     cy.visit("/presentations");
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
   });
+
+  it("should take favorited ids from session cookie", () => { });
 });

--- a/cypress/e2e/presentations.cy.js
+++ b/cypress/e2e/presentations.cy.js
@@ -54,7 +54,7 @@ describe("Presentations Page", () => {
     cy.getByTestId(presentationFavoriteToggle).click();
     cy.getByTestId(presentationFavoriteToggle).contains("♥️");
 
-    cy.reload()
+    cy.reload();
     cy.getByTestId(presentationFavoriteToggle).contains("♥️");
   });
 

--- a/cypress/e2e/presentations.cy.js
+++ b/cypress/e2e/presentations.cy.js
@@ -58,6 +58,20 @@ describe("Presentations Page", () => {
     cy.getByTestId(presentationFavoriteToggle).contains("♥️");
   });
 
+  it("should persist favorites across search", () => {
+    cy.visit("/presentations");
+    // initial state is unfavorited
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
+    // toggle to be favorited
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
+
+    cy.getByTestId("presentation-search").type("transform customized");
+    // ensure search has finished before asserting favorited row
+    cy.getByTestId("presentation-row").should("have.length", 1);
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
+  });
+
   it("should allow for favoriting on list page, favorite persists on detail page", () => {
     cy.visit("/presentations");
     // initial state is unfavorited

--- a/cypress/e2e/presentations.cy.js
+++ b/cypress/e2e/presentations.cy.js
@@ -46,6 +46,18 @@ describe("Presentations Page", () => {
     cy.getByTestId(presentationFavoriteToggle).contains("♡");
   });
 
+  it("should persist favorites across sessions", () => {
+    cy.visit("/presentations");
+    // initial state is unfavorited
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
+    // toggle to be favorited
+    cy.getByTestId(presentationFavoriteToggle).click();
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
+
+    cy.reload()
+    cy.getByTestId(presentationFavoriteToggle).contains("♥️");
+  });
+
   it("should allow for favoriting on list page, favorite persists on detail page", () => {
     cy.visit("/presentations");
     // initial state is unfavorited
@@ -70,5 +82,22 @@ describe("Presentations Page", () => {
     cy.getByTestId(presentationFavoriteToggle).contains("♥️");
   });
 
-  it("should take favorited ids from session cookie", () => { });
+  it("should take favorited ids from session cookie", () => {
+    const sessionObj = {
+      favorite_presentations: [
+        "326fb434-e199-427f-a523-042969cb4a86",
+        "7307b163-dcbe-4d12-ad18-43f5b7af1528",
+      ],
+    };
+    const encodedCookie = btoa(JSON.stringify(sessionObj));
+    cy.setCookie("session", encodedCookie);
+    cy.visit("/presentations");
+    // all presentations in session cookie should be favorited
+    sessionObj.favorite_presentations.forEach((presentationId) => {
+      cy.getByTestId(`favorite-${presentationId}`).contains("♥️");
+    });
+
+    // other presentations should not be favorited
+    cy.getByTestId(presentationFavoriteToggle).contains("♡");
+  });
 });

--- a/cypress/e2e/presentations.cy.js
+++ b/cypress/e2e/presentations.cy.js
@@ -71,24 +71,20 @@ describe("Presentations Page", () => {
     );
   });
 
-  // there is state shared between these tests, due to favorites living on the server
-  // this should go away once we use cookie based view state
   it("should allow for favoriting on detail page, favorite persists on list page", () => {
     cy.visit("/presentations/7415a027-865c-4112-aff4-f617cc3093d2");
-    // initial state is favorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♥️",
-    );
-    // toggle to be unfavorited
-    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
     cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
       "♡",
+    );
+    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").click();
+    cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
+      "♥️",
     );
 
     // toggle off
     cy.visit("/presentations");
     cy.getByTestId("favorite-7415a027-865c-4112-aff4-f617cc3093d2").contains(
-      "♡",
+      "♥️",
     );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cookie-session": "^2.1.0",
         "express": "^4.19.2",
         "express-handlebars": "^7.1.3",
-        "handlebars": "^4.7.8",
         "nodemon": "^3.1.4"
       },
       "devDependencies": {
@@ -810,10 +810,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-session": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.1.0.tgz",
+      "integrity": "sha512-u73BDmR8QLGcs+Lprs0cfbcAPKl2HnPcjpwRXT41sEV4DRJ2+W0vJEEZkG31ofkx+HZflA70siRIjiTdIodmOQ==",
+      "dependencies": {
+        "cookies": "0.9.1",
+        "debug": "3.2.7",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cookie-session/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/cookie-session/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -1895,6 +1934,17 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -2210,6 +2260,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2853,6 +2911,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node --watch src/server.js",
-    "dev": "nodemon -e hbs,js -V src/server.js",
+    "dev": "nodemon -e hbs,js -i cypress/ -V src/server.js",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cookie-session": "^2.1.0",
     "express": "^4.19.2",
     "express-handlebars": "^7.1.3",
     "nodemon": "^3.1.4"

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { engine } from "express-handlebars";
+import cookieSession from "cookie-session";
 import presentations from "./db/presentations.json" with { type: "json" };
 import searchPresentations from "./utils/search.js";
 import * as path from "node:path";
@@ -13,8 +14,25 @@ app.set("views", path.resolve(__dirname, "./views"));
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(
+  cookieSession({
+    name: "session",
+    keys: ["key1"],
+    httpOnly: false,
+    signed: false,
+    maxAge: 365 * 24 * 60 * 60 * 1000, // one year
+  }),
+);
 app.use((req, _, next) => {
   console.log(`request for ${req.path}`);
+  next();
+});
+
+app.use((req, _, next) => {
+  let favoritePresentations = req.session.favorite_presentations;
+  if (favoritePresentations == null) {
+    req.session.favorite_presentations = [];
+  }
 
   next();
 });
@@ -23,7 +41,8 @@ app.get("/", (_, res) => {
   res.render("index", { test: "hi there" });
 });
 
-app.get("/presentations", (_, res) => {
+app.get("/presentations", (req, res) => {
+  const favorites = req.session.favorite_presentations
   const presentationsWithFavorites = presentations.map((p) => ({
     ...p,
     favorited: favorites.includes(p._id),
@@ -33,6 +52,7 @@ app.get("/presentations", (_, res) => {
 
 app.get("/presentations/:id", (req, res) => {
   const presID = req.params.id;
+  const favorites = req.session.favorite_presentations
   const presentation = presentations.find(
     (presentation) => presentation._id == presID,
   );
@@ -46,8 +66,6 @@ app.get("/presentations/:id", (req, res) => {
   });
 });
 
-// temporary to hold favorite state in server state until we get viewstate in place
-let favorites = [];
 
 app.post("/search", (req, res) => {
   const presentationsFound = searchPresentations(
@@ -60,6 +78,7 @@ app.post("/search", (req, res) => {
 
 app.put("/presentations/favorite/:id", (req, res) => {
   const id = req.params.id;
+  let favorites = req.session.favorite_presentations
   // what if id doesn't exist???
 
   // we'll toggle favorite on and off with this endpoint
@@ -68,6 +87,7 @@ app.put("/presentations/favorite/:id", (req, res) => {
     ? favorites.filter((f) => f !== id)
     : [...favorites, id];
 
+  req.session.favorite_presentations = favorites
   res.render("favorited_response", {
     favorited: !isExistingFavorite,
     id,

--- a/src/server.js
+++ b/src/server.js
@@ -68,12 +68,18 @@ app.get("/presentations/:id", (req, res) => {
 
 
 app.post("/search", (req, res) => {
+  const favorites = req.session.favorite_presentations
   const presentationsFound = searchPresentations(
     req.body.search,
     presentations,
   );
+  // move into utility method?
+  const presentationsWithFavorites = presentationsFound .map((p) => ({
+    ...p,
+    favorited: favorites.includes(p._id),
+  }));
 
-  res.render("search", { presentations: presentationsFound, layout: false });
+  res.render("search", { presentations: presentationsWithFavorites , layout: false });
 });
 
 app.put("/presentations/favorite/:id", (req, res) => {

--- a/src/utils/favorites.js
+++ b/src/utils/favorites.js
@@ -1,0 +1,6 @@
+export function mergePresentationsWithFavorites(presentations, favoriteIds){
+  return presentations.map((p) => ({
+    ...p,
+    favorited: favoriteIds.includes(p._id),
+  }));
+}


### PR DESCRIPTION
Builds on #9 where favorite state is put into a cookie. This cookie acts as state between client and server, and survives across sessions i.e. you can close your browser, access the site and your favorite state persists.  To enable this, I added the `cookie-session` [npm package](https://expressjs.com/en/resources/middleware/cookie-session.html). 

- wired up session cookies
- replaced existing logic to look in `req.session` for favorite presentations instead of local variable
- added tests to prove this all out