### PR TITLE
feat: create header with page animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "express": "^4.19.2",
         "express-handlebars": "^7.1.3",
-        "handlebars": "^4.7.8",
         "nodemon": "^3.1.4"
       },
       "devDependencies": {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1,0 +1,32 @@
+@view-transition {
+    navigation: auto;
+}
+@keyframes collapse {
+    from {
+        transform: rotate(0) scale(1) translateX(0) translateY(0);
+    }
+    to {
+        transform: rotate(-300deg) scale(0) translateX(-100%) translateY(100%);
+    }
+}
+@keyframes expand {
+    from {
+        clip-path: inset(50% 50% 50% 50%);
+        transform: scale(0) translateX(100%) translateY(-70%);
+        background: skyblue;
+    }
+    to {
+        clip-path: inset(0 0 0 0);
+        transform: scale(1) translateX(0) translateY(0);
+        background: inherit;
+    }
+}
+::view-transition-old(page-transition) {
+    animation: 600ms ease-out both collapse;
+}
+::view-transition-new(page-transition) {
+    animation: 600ms ease-in both expand;
+}
+body {
+    view-transition-name: page-transition;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,10 @@ app.get("/", (_, res) => {
 });
 
 app.get("/presentations", (_, res) => {
-  res.render("presentations", { presentations });
+  res.render("presentations", {
+    title: "Presentations",
+    presentations,
+  });
 });
 
 app.get("/presentations/:id", (req, res) => {
@@ -37,6 +40,7 @@ app.get("/presentations/:id", (req, res) => {
     return
   }
   res.render("presentation_description", {
+    title: presentation.name,
     presentation: presentation,
   });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,7 @@ app.use((req, _, next) => {
 
   next();
 });
+app.use("/public", express.static(path.resolve(__dirname, 'public')));
 
 app.get("/", (_, res) => {
   res.render("index", { test: "hi there" });

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -19,6 +19,14 @@
       @view-transition {
         navigation: auto;
       }
+      @keyframes collapse {
+        from {
+          transform: rotate(0) scale(1) translateX(0) translateY(0);
+        }
+        to {
+          transform: rotate(-300deg) scale(0) translateX(-100%) translateY(100%);
+        }
+      }
       @keyframes expand {
         from {
           clip-path: inset(50% 50% 50% 50%);
@@ -31,12 +39,14 @@
           background: inherit;
         }
       }
-      body {
-        view-transition-name: page-transition;
+      ::view-transition-old(page-transition) {
+        animation: 600ms ease-out both collapse;
       }
-      ::view-transition-old(page-transition) { }
       ::view-transition-new(page-transition) {
         animation: 600ms ease-in both expand;
+      }
+      body {
+        view-transition-name: page-transition;
       }
     </style>
   </head>

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -15,40 +15,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="view-transition" content="same-origin" />
     <script src="https://unpkg.com/htmx.org@2.0.0"></script>
-    <style>
-      @view-transition {
-        navigation: auto;
-      }
-      @keyframes collapse {
-        from {
-          transform: rotate(0) scale(1) translateX(0) translateY(0);
-        }
-        to {
-          transform: rotate(-300deg) scale(0) translateX(-100%) translateY(100%);
-        }
-      }
-      @keyframes expand {
-        from {
-          clip-path: inset(50% 50% 50% 50%);
-          transform: scale(0) translateX(100%) translateY(-70%);
-          background: skyblue;
-        }
-        to {
-          clip-path: inset(0 0 0 0);
-          transform: scale(1) translateX(0) translateY(0);
-          background: inherit;
-        }
-      }
-      ::view-transition-old(page-transition) {
-        animation: 600ms ease-out both collapse;
-      }
-      ::view-transition-new(page-transition) {
-        animation: 600ms ease-in both expand;
-      }
-      body {
-        view-transition-name: page-transition;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" href="/public/styles.css" />
   </head>
   <body>
     <header>

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -19,34 +19,24 @@
       @view-transition {
         navigation: auto;
       }
-
-      @keyframes fade-in {
-        from { opacity: 0; }
+      @keyframes expand {
+        from {
+          clip-path: inset(50% 50% 50% 50%);
+          transform: scale(0) translateX(100%) translateY(-70%);
+          background: skyblue;
+        }
+        to {
+          clip-path: inset(0 0 0 0);
+          transform: scale(1) translateX(0) translateY(0);
+          background: inherit;
+        }
       }
-
-      @keyframes fade-out {
-        to { opacity: 0; }
-      }
-
-      @keyframes slide-from-right {
-        from { transform: translateX(90px); }
-      }
-
-      @keyframes slide-to-left {
-        to { transform: translateX(-90px); }
-      }
-
       body {
         view-transition-name: page-transition;
       }
-
-      ::view-transition-old(page-transition) {
-        animation: 180ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
-        600ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
-      }
+      ::view-transition-old(page-transition) { }
       ::view-transition-new(page-transition) {
-        animation: 420ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
-        600ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+        animation: 600ms ease-in both expand;
       }
     </style>
   </head>

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -1,15 +1,66 @@
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
     />
-    <title></title>
+    <title>
+      {{#if title}}
+        {{title}} - Frontend Forward 2024
+      {{^}}
+        Frontend Forward 2024
+      {{/if}}
+    </title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="view-transition" content="same-origin" />
     <script src="https://unpkg.com/htmx.org@2.0.0"></script>
+    <style>
+      @view-transition {
+        navigation: auto;
+      }
+
+      @keyframes fade-in {
+        from { opacity: 0; }
+      }
+
+      @keyframes fade-out {
+        to { opacity: 0; }
+      }
+
+      @keyframes slide-from-right {
+        from { transform: translateX(90px); }
+      }
+
+      @keyframes slide-to-left {
+        to { transform: translateX(-90px); }
+      }
+
+      body {
+        view-transition-name: page-transition;
+      }
+
+      ::view-transition-old(page-transition) {
+        animation: 180ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+        600ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+      }
+      ::view-transition-new(page-transition) {
+        animation: 420ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+        600ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+      }
+    </style>
   </head>
   <body>
-    {{{body}}}
+    <header>
+      <nav hx-boost="true">
+        <ul>
+          <li><a href="/" hx-swap="innerHTML transition:true" hx-target="body">Home</a></li>
+          <li><a href="/presentations" hx-swap="innerHTML transition:true" hx-target="body">Presentations</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      {{{body}}}
+    </main>
   </body>
 </html>

--- a/src/views/presentation_description.hbs
+++ b/src/views/presentation_description.hbs
@@ -1,5 +1,5 @@
 <h1>{{presentation.name}}</h1>
-<div>{{presentation.avatar}}</div>
+<img src="{{presentation.avatar}}" fetchpriority="high" alt="{{presentation.firstName}} {{presentation.lastName}}" />
 <div>{{presentation.firstName}} {{presentation.lastName}}</div>
 <div>{{presentation.email}}</div>
 <div>{{presentation._id}}</div>


### PR DESCRIPTION
I created a basic header for links, utilizing:

* [hx-boost](https://htmx.org/attributes/hx-boost/) to provide SPA page navigation. It works without JS too!
* [view transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) to make a weird animation. It works without JS too!

Note that view transitions aren't supported yet in firefox so you'll need to view it with Chrome or Safari. Also... let me know if you think I should change the animation. I was just trying to add something relatively simple 😄 