### PR TITLE
[chore]: Add vercel.json to prep for deployment via vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "src/server.js",
+      "use": "@vercel/node",
+      "config": { "includeFiles": ["public/**"] }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "src/server.js"
+    }
+  ]
+}


### PR DESCRIPTION
Following [this blog post](https://medium.com/@ShrianshAgarwal/deploying-express-backend-to-vercel-7664ef880005), I was able to deploy a similar express driven app via vercel, which includes module type code and a public directory. We can copy the same config in this project. @monicaleep you'll need to create a vercel account if you don't have one, and setup this project for deployments. 

It's basically:

- sign in or create a vercel account using your github credentials
- find the project in the list of github projects that vercel can see
- click OK at deployment. I didn't have to change any config in the vercel UI